### PR TITLE
Update common-optical-flow-sensor-setup

### DIFF
--- a/common/source/docs/common-optical-flow-sensor-setup.rst
+++ b/common/source/docs/common-optical-flow-sensor-setup.rst
@@ -121,7 +121,7 @@ Second Flight
 #. For EKF2, set :ref:`EK2_GPS_TYPE <EK2_GPS_TYPE>` = 3; for EKF3, set :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 5 and :ref:`EK3_SRC1_POSXY <EK3_SRC1_POSXY>` = 0 to make the EKF ignore GPS and use the flow sensor
 #. Ensure you have a loiter and hover mode available on you transmitter.
 #. Set "EKF Origin" on Ground Control Station map. In Mission Planner, right click, select "Set Home here", and choose to set "set EKF origin here".
-#. Take-off in loiter and bring the Copter/QuadPlane to about 1m height
+#. Take-off in loiter and bring the Copter/QuadPlane to about 1m height (Or Take off in STABILIZE or AltHold and once Copter/QuadPlane's altitude reaches above Rangefinder's `RNGFND1_MIN_CM <https://ardupilot.org/copter/docs/parameters.html#rngfnd1-min-cm>`__ (about 60 cm), switch to loiter mode, in case your Rangefinder's `RNGFND1_MIN_CM <https://ardupilot.org/copter/docs/parameters.html#rngfnd1-min-cm>`__ is more than 10. )
 #. If the vehicle starts to accelerate away or there is erratic pitch or roll
    movement, then switch to hover and land. You will need to
    download the log file and share it on `the forums <https://discuss.ardupilot.org/c/arducopter>`__ to understand why.


### PR DESCRIPTION
In the Second Flight test, I want to add details in the 4th point so that other new users can not get stuck on this step. I have faced this issue and after getting the solution. I have added details there. For the reference for this change, I request to go through this discussion: https://discuss.ardupilot.org/t/mode-change-to-loiter-failed-requires-position-with-only-px4flow/101885?u=yash_thummar where I have explained it in more details.